### PR TITLE
doc: refining the test-case requirement

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ Collaborators sign-off on a Pull Request by explicitly stating their approval in
 
 Exception to this process is allowed for high-priority changes that address security vulnerabilities. A shorter review period and modified sign-off process may be necessary depending on the nature of the change and severity of the issue. It is recommended that the TSC establish a Security Working Group of Collaborators with recognized security expertise that can be tasked with reviewing security related Pull Requests and determining an appropriate review process.
 
-All Pull Requests that either fix bugs or introduce new functionality require at least one test case demonstrating the defect or validating the intended functionality. For bug fixes, the test should fail before the change, and pass after the change.
+All Pull Requests that either fix bugs or introduce new functionality require at least one test case demonstrating the defect or validating the intended functionality. For bug fixes, the test should fail before the change, and pass after the change. In exceptional cases, such as environments or failure modes that are difficult to reproduce, a detailed description of how to verify the fix may be accepted in lieu of a specific test. 
 
 Pull Requests for changes intended to improve performance require a benchmark demonstrating the performance impact. The benchmark should demonstrate improved performance after the change is applied.
 


### PR DESCRIPTION
Makes allowance for cases where a specific test case may be difficult.

Fixes: https://github.com/jasnell/dev-policy/issues/40

/cc @srl295 @orangemocha @Fishrock123 
